### PR TITLE
Respect parsers config

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Type: `Boolean` <br>
 
 If column contains list of values separated by comma in return object it will be as an array
 
+### parserConfig
+Type: `Object` <br>
+
+Optional field to pass custom configuration to underlying papaparse parser. Default options, which can't be overridden:
+**skipEmptyLines**, **complete** and **error**
+
+For available options please check  [papaparse](https://www.papaparse.com/docs#config) documentation
+
 #### Config example ####
 ```javascript
 const config = {
@@ -156,7 +164,14 @@ const config = {
             inputName: 'country',
             optional: true
         }
-    ]
+    ],
+    parserConfig: {
+        transform: (value, field) => {
+            if (field === 2) {
+                return value.toLocaleLowerCase();
+            }
+        },
+    }
 }
 ```
 

--- a/src/csv-file-validator.js
+++ b/src/csv-file-validator.js
@@ -26,6 +26,7 @@
 			}
 
 			Papa.parse(csvFile, {
+				...config.parserConfig,
 				skipEmptyLines: true,
 				complete: function (results) {
 					resolve(_prepareDataAndValidateFile(results.data, config));
@@ -59,7 +60,8 @@
 				);
 			}
 
-			row.forEach(function (columnValue, columnIndex) {
+			row.forEach(function (columnValueRaw, columnIndex) {
+				const columnValue = columnValueRaw.replace(/^\ufeff/, '') // Strip BOM character
 				const valueConfig = config.headers[columnIndex];
 
 				if (!valueConfig) {
@@ -86,7 +88,7 @@
 					}
 				}
 
-				if (valueConfig.required && !columnValue.length) {
+				if (valueConfig.required && (columnValue === undefined || (typeof columnValue === 'string' && !columnValue.length))) {
 					file.inValidMessages.push(
 						_isFunction(valueConfig.requiredError)
 							? valueConfig.requiredError(valueConfig.name, rowIndex + 1, columnIndex + 1)


### PR DESCRIPTION
- New Config property to respect papaparse config
- Modified validation check to have other types then string in case if "tranformation" is used in papaparse config